### PR TITLE
Kb friends remove

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -29,7 +29,14 @@ export default class ApplicationViews extends Component {
         <Route
           path="/friends"
           render={props => {
-            return <FriendList />;
+            return (
+              <FriendList
+                getFriends={this.props.getFriends}
+                addFriend={this.props.addFriend}
+                removeFriend={this.props.removeFriend}
+                friends={this.props.friends}
+              />
+            );
           }}
         />
 

--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -1,8 +1,8 @@
 import { Route } from "react-router-dom";
 import React, { Component } from "react";
-import FriendList from "./friends/FriendList";
 import EventList from "./events/EventList";
 import EventForm from "./events/EventForm";
+import FriendList from "./friends/FriendList";
 
 export default class ApplicationViews extends Component {
   render() {

--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -1,54 +1,59 @@
 import { Route } from "react-router-dom";
 import React, { Component } from "react";
+import FriendList from "./friends/FriendList";
 
 export default class ApplicationViews extends Component {
-
   render() {
     return (
       <React.Fragment>
-
         <Route
-          exact path="/" render={props => {
-            return null
+          exact
+          path="/"
+          render={props => {
+            return null;
             // Remove null and return the component which will show news articles
           }}
         />
 
         <Route
-          exact path="/register" render={props => {
-            return null
+          exact
+          path="/register"
+          render={props => {
+            return null;
             // Remove null and return the component which will handle user registration
           }}
         />
 
         <Route
-          path="/friends" render={props => {
-            return null
-            // Remove null and return the component which will show list of friends
+          path="/friends"
+          render={props => {
+            return <FriendList />;
           }}
         />
 
         <Route
-          path="/messages" render={props => {
-            return null
+          path="/messages"
+          render={props => {
+            return null;
             // Remove null and return the component which will show the messages
           }}
         />
 
         <Route
-          path="/tasks" render={props => {
-            return null
+          path="/tasks"
+          render={props => {
+            return null;
             // Remove null and return the component which will show the user's tasks
           }}
         />
 
         <Route
-          path="/events" render={props => {
-            return null
+          path="/events"
+          render={props => {
+            return null;
             // Remove null and return the component which will show the user's events
           }}
         />
-
       </React.Fragment>
     );
   }

--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -1,34 +1,31 @@
 import { Route } from "react-router-dom";
 import React, { Component } from "react";
-import EventList from "./events/EventList";
-import EventForm from "./events/EventForm";
-import FriendList from "./friends/FriendList";
+import EventList from './events/EventList'
+import EventForm from './events/EventForm'
+import FriendList from "./friends/FriendList"
 
 export default class ApplicationViews extends Component {
+
   render() {
     return (
       <React.Fragment>
+
         <Route
-          exact
-          path="/"
-          render={props => {
-            return null;
+          exact path="/" render={props => {
+            return null
             // Remove null and return the component which will show news articles
           }}
         />
 
         <Route
-          exact
-          path="/register"
-          render={props => {
-            return null;
+          exact path="/register" render={props => {
+            return null
             // Remove null and return the component which will handle user registration
           }}
         />
 
         <Route
-          path="/friends"
-          render={props => {
+          path="/friends" render={props => {
             return (
               <FriendList
                 getFriends={this.props.getFriends}
@@ -41,37 +38,33 @@ export default class ApplicationViews extends Component {
         />
 
         <Route
-          path="/messages"
-          render={props => {
-            return null;
+          path="/messages" render={props => {
+            return null
             // Remove null and return the component which will show the messages
           }}
         />
 
         <Route
-          path="/tasks"
-          render={props => {
-            return null;
+          path="/tasks" render={props => {
+            return null
             // Remove null and return the component which will show the user's tasks
           }}
         />
 
-        <Route
-          exact
-          path="/events"
-          render={props => {
-            return <EventList {...props} />;
+        <Route exact
+          path="/events" render={props => {
+            return <EventList {...props} />
             // Remove null and return the component which will show the user's events
           }}
         />
 
         <Route
-          path="/events/new"
-          render={props => {
-            return <EventForm {...props} />;
+          path="/events/new" render={props => {
+            return <EventForm {...props} />
             // Remove null and return the component which will show the user's events
           }}
         />
+
       </React.Fragment>
     );
   }

--- a/src/components/Nutshell.js
+++ b/src/components/Nutshell.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import NavBar from "./nav/NavBar";
-import ApplicationViews from "./ApplicationViews";
+import FriendWrapper from "./friends/FriendWrapper";
 import "./Nutshell.css";
 
 class Nutshell extends Component {
@@ -8,7 +8,7 @@ class Nutshell extends Component {
     return (
       <React.Fragment>
         <NavBar />
-        <ApplicationViews />
+        <FriendWrapper />
       </React.Fragment>
     );
   }

--- a/src/components/friends/FriendCard.js
+++ b/src/components/friends/FriendCard.js
@@ -1,0 +1,31 @@
+import React, { Component } from "react";
+import { Button, Card, ListGroup } from "react-bootstrap";
+import "./Friend.css";
+
+class FriendCard extends Component {
+  render() {
+    console.log(this.props.friend);
+    return (
+      <ListGroup>
+        <Card className="friend">
+          <Card.Body className="friend__content">
+            <Card.Text className="friend__name">
+              Name: {this.props.friend.fullName}
+            </Card.Text>
+            <Card.Text className="friend__email">
+              Email: {this.props.friend.email}
+            </Card.Text>
+          </Card.Body>
+          <Button
+            type="button"
+            className="btn-primary"
+            onClick={() => this.props.deleteFriend(this.props.friend.id)}>
+            Remove Friend
+          </Button>
+        </Card>
+      </ListGroup>
+    );
+  }
+}
+
+export default FriendCard;

--- a/src/components/friends/FriendCard.js
+++ b/src/components/friends/FriendCard.js
@@ -4,9 +4,8 @@ import "./Friend.css";
 
 class FriendCard extends Component {
   render() {
-    console.log(this.props.friend);
     return (
-      <ListGroup>
+      <ListGroup.Item>
         <Card className="friend">
           <Card.Body className="friend__content">
             <Card.Text className="friend__name">
@@ -23,7 +22,7 @@ class FriendCard extends Component {
             Remove Friend
           </Button>
         </Card>
-      </ListGroup>
+      </ListGroup.Item>
     );
   }
 }

--- a/src/components/friends/FriendList.js
+++ b/src/components/friends/FriendList.js
@@ -1,0 +1,37 @@
+import React, { Component } from "react";
+import FriendCard from "./FriendCard";
+import APIManager from "../../modules/APIManager";
+import { ListGroup } from "react-bootstrap";
+
+class FriendList extends Component {
+  state = {
+    friends: [],
+    loadingStatus: true
+  };
+  deleteFriend = id => {};
+  addFriend = id => {};
+  componentDidMount() {
+    APIManager.get(
+      `friends/?loggedInUser=${localStorage.getItem("userId")}&_expand=user`
+    ).then(friends => {
+      this.setState({ friends: friends, loadingStatus: false });
+    });
+  }
+  render() {
+    return (
+      <ListGroup>
+        {this.state.friends.map(friend => {
+          return (
+            <FriendCard
+              key={friend.id}
+              friend={friend.user}
+              deleteFriend={this.deleteFriend}
+            />
+          );
+        })}
+      </ListGroup>
+    );
+  }
+}
+
+export default FriendList;

--- a/src/components/friends/FriendList.js
+++ b/src/components/friends/FriendList.js
@@ -1,31 +1,25 @@
 import React, { Component } from "react";
 import FriendCard from "./FriendCard";
-import APIManager from "../../modules/APIManager";
 import { ListGroup } from "react-bootstrap";
 
 class FriendList extends Component {
   state = {
-    friends: [],
     loadingStatus: true
   };
-  deleteFriend = id => {};
   addFriend = id => {};
   componentDidMount() {
-    APIManager.get(
-      `friends/?loggedInUser=${localStorage.getItem("userId")}&_expand=user`
-    ).then(friends => {
-      this.setState({ friends: friends, loadingStatus: false });
-    });
+    this.props.getFriends();
+    this.setState({ loadingStatus: false });
   }
   render() {
     return (
       <ListGroup>
-        {this.state.friends.map(friend => {
+        {this.props.friends.map(friend => {
           return (
             <FriendCard
               key={friend.id}
               friend={friend.user}
-              deleteFriend={this.deleteFriend}
+              deleteFriend={this.props.removeFriend}
             />
           );
         })}

--- a/src/components/friends/FriendWrapper.js
+++ b/src/components/friends/FriendWrapper.js
@@ -1,0 +1,69 @@
+import React, { Component } from "react";
+import APIManager from "../../modules/APIManager";
+import ApplicationViews from "../ApplicationViews";
+
+class FriendWrapper extends Component {
+  state = {
+    friends: []
+  };
+  componentDidMount() {
+    this.getFriends();
+  }
+  getFriends = () => {
+    APIManager.get(
+      `friends/?loggedInUser=${localStorage.getItem("userId")}&_expand=user`
+    ).then(friends => {
+      this.setState({ friends: friends });
+    });
+  };
+  addFriend = id => {
+    if (Number(localStorage["userId"]) === Number(id)) {
+      window.alert(
+        "Not sure how you did that, but you cannot add yourself as a friend"
+      );
+    } else {
+      APIManager.get(`friends?loggedInUser=${localStorage["userId"]}`)
+        .then(friends => {
+          if (friends.find(friend => Number(friend.userId) === Number(id))) {
+            window.alert("That user is already a friend");
+          } else {
+            APIManager.post(`friends/`, {
+              loggedInUser: Number(localStorage["userId"]),
+              userId: Number(id)
+            });
+          }
+        })
+        .then(() => {
+          this.getFriends();
+        });
+    }
+  };
+  removeFriend = id => {
+    if (Number(localStorage["userId"]) === Number(id)) {
+      window.alert(
+        "Not sure how you did that, but you cannot delete yourself as a friend"
+      );
+    } else {
+      APIManager.get(
+        `friends?loggedInUser=${localStorage["userId"]}&userId=${id}`
+      ).then(friendResponse => {
+        APIManager.delete(`friends/${friendResponse[0].id}`).then(() => {
+          this.getFriends();
+        });
+      });
+    }
+  };
+
+  render() {
+    return (
+      <ApplicationViews
+        friends={this.state.friends}
+        addFriend={this.addFriend}
+        removeFriend={this.removeFriend}
+        getFriends={this.getFriends}
+      />
+    );
+  }
+}
+
+export default FriendWrapper;


### PR DESCRIPTION
# Description

User can remove friends from friends tab. `FriendsWrapper` now holds the ApplicationViews component, so any changes to friend state will cause cause a re-render for all components. This will update articles and events by no longer showing removed friends' content.

There are also some functions that can be passed as props for adding a friend through messages. It will also trigger a re-render and update the other components.

Fixes #13

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions

Please describe the tests required to verify your changes. Provide instructions so PR Tester can check functionality. Please also list any relevant details for your tests

Checkout the branch `kb-friends-remove`
Click remove on a friend in the friend tab

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
