### PR TITLE
added typeahead search to friends

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3740,6 +3740,15 @@
         "sha.js": "^2.4.8"
       }
     },
+    "create-react-context": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
+      "integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
+      "requires": {
+        "gud": "^1.0.0",
+        "warning": "^4.0.3"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -10567,6 +10576,67 @@
         "warning": "^4.0.3"
       }
     },
+    "react-bootstrap-typeahead": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/react-bootstrap-typeahead/-/react-bootstrap-typeahead-3.4.7.tgz",
+      "integrity": "sha512-eUm3hqX12p+iM+1Y0HKF891/ACbKyGep7PsC2pjFGZL48r25Jlv3X2xmV5D8N0wE/YPFZF7iW913tyAlwqjw1Q==",
+      "requires": {
+        "classnames": "^2.2.0",
+        "create-react-context": "^0.3.0",
+        "escape-string-regexp": "^1.0.5",
+        "invariant": "^2.2.1",
+        "lodash": "^4.17.2",
+        "prop-types": "^15.5.8",
+        "prop-types-extra": "^1.0.1",
+        "react-overlays": "^0.8.1",
+        "react-popper": "^1.0.0",
+        "warning": "^4.0.1"
+      },
+      "dependencies": {
+        "dom-helpers": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+          "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+          "requires": {
+            "@babel/runtime": "^7.1.2"
+          }
+        },
+        "react-overlays": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-0.8.3.tgz",
+          "integrity": "sha512-h6GT3jgy90PgctleP39Yu3eK1v9vaJAW73GOA/UbN9dJ7aAN4BTZD6793eI1D5U+ukMk17qiqN/wl3diK1Z5LA==",
+          "requires": {
+            "classnames": "^2.2.5",
+            "dom-helpers": "^3.2.1",
+            "prop-types": "^15.5.10",
+            "prop-types-extra": "^1.0.1",
+            "react-transition-group": "^2.2.0",
+            "warning": "^3.0.0"
+          },
+          "dependencies": {
+            "warning": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+              "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+              "requires": {
+                "loose-envify": "^1.0.0"
+              }
+            }
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+          "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        }
+      }
+    },
     "react-dev-utils": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-9.1.0.tgz",
@@ -10746,6 +10816,19 @@
         "prop-types": "^15.7.2",
         "uncontrollable": "^7.0.0",
         "warning": "^4.0.3"
+      }
+    },
+    "react-popper": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.6.tgz",
+      "integrity": "sha512-kLTfa9z8n+0jJvRVal9+vIuirg41rObg4Bbrvv/ZfsGPQDN9reyVVSxqnHF1ZNgXgV7x11PeUfd5ItF8DZnqhg==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "create-react-context": "^0.3.0",
+        "popper.js": "^1.14.4",
+        "prop-types": "^15.6.1",
+        "typed-styles": "^0.0.7",
+        "warning": "^4.0.2"
       }
     },
     "react-router": {
@@ -12667,6 +12750,11 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "typed-styles": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
+      "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "bootstrap": "^4.4.1",
     "react": "^16.12.0",
     "react-bootstrap": "^1.0.0-beta.16",
+    "react-bootstrap-typeahead": "^3.4.7",
     "react-dom": "^16.12.0",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.2.0"

--- a/src/components/friends/FriendSearch.js
+++ b/src/components/friends/FriendSearch.js
@@ -1,9 +1,12 @@
 import React, { Component } from "react";
-import { InputGroup, FormControl, Button } from "react-bootstrap";
+import { InputGroup, Button } from "react-bootstrap";
 import APIManager from "../../modules/APIManager";
+import { Typeahead } from "react-bootstrap-typeahead";
+import "react-bootstrap-typeahead/css/Typeahead.css";
 
 class FriendSearch extends Component {
   state = {
+    users: [],
     input: ""
   };
   handleInputChange = evt => {
@@ -24,14 +27,22 @@ class FriendSearch extends Component {
       }
     });
   };
+  componentDidMount() {
+    APIManager.get("users").then(users =>
+      this.setState({ users: users.map(user => user.fullName) })
+    );
+  }
   render() {
     return (
       <InputGroup className="friend__search">
-        <FormControl
-          placeholder="Add a new friend"
-          id="friend-search-input"
-          onChange={this.handleInputChange}
-        />
+        <Typeahead
+        id="typeahead-users"
+          labelKey="name"
+          options={this.state.users}
+          onChange={input => {
+            this.setState({ input: input });
+          }}
+          placeholder="Select a person..."></Typeahead>
         <InputGroup.Append>
           <Button variant="success" onClick={this.searchAndAddFriend}>
             Add


### PR DESCRIPTION
# Description

This changes the friends search to use a typeahead search instead. It grabs each users' name into an array and presents anything that matches the search term.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions

Checkout the shiny new `kb-friend-typeahead-search` branch
Search for people, watch matches pop up, click the name, then click add


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
