### PR TITLE
fixed edit to display for user only and implemented login for messages

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -48,7 +48,11 @@ export default class ApplicationViews extends Component {
 
         <Route
           path="/messages" render={props => {
-            return <MessageList {...props} />
+            if (this.props.user) {
+                return <MessageList {...props} {...this.props} />
+              }  else {
+                return <Redirect to="/login" />
+              }
           }}
         />
 

--- a/src/components/message/MessageCard.js
+++ b/src/components/message/MessageCard.js
@@ -67,7 +67,6 @@ class MessageCard extends Component {
                         defaultValue={this.props.message.message}></textarea>
                     <p className="timestamp">{formatTimestamp(this.props.message.timestamp).split(",")[0]}<br />
                         {formatTimestamp(this.props.message.timestamp).split(",")[1]}</p>
-                    <button onClick={this.editMessage}>Edit</button>
                     <button onClick={this.saveMessage}>Save</button>
                 </Card>
             )

--- a/src/components/message/MessageCard.js
+++ b/src/components/message/MessageCard.js
@@ -20,7 +20,7 @@ class MessageCard extends Component {
     saveMessage = () => {
         const newMessageObj = {
             id: this.state.messageObj.id,
-            userId: this.state.messageObj.userId,
+            userId: this.props.getUser.id,
             message: this.state.newMessage,
             timestamp: this.state.messageObj.timestamp
         }
@@ -44,10 +44,12 @@ class MessageCard extends Component {
             messageObj: this.props.message,
             newMessage: this.props.message.message
         })
+        console.log("this.props", this.props)
     }
 
     render() {
-        if(this.state.editMode === false) {
+        if(this.props.message.userId === this.props.getUser.id &&
+            this.state.editMode === false) {
             return (
                 <Card>
                     <span>{this.props.message.user.fullName} - {this.props.message.message}</span>
@@ -56,7 +58,8 @@ class MessageCard extends Component {
                     <button onClick={this.editMessage}>Edit</button>
                 </Card>
             )
-        } else {
+        } else if(this.props.message.userId === this.props.getUser.id &&
+            this.state.editMode === true)  {
             return (
                 <Card>
                     <span>{this.props.message.user.fullName} - </span>
@@ -66,6 +69,14 @@ class MessageCard extends Component {
                         {formatTimestamp(this.props.message.timestamp).split(",")[1]}</p>
                     <button onClick={this.editMessage}>Edit</button>
                     <button onClick={this.saveMessage}>Save</button>
+                </Card>
+            )
+        } else {
+            return (
+                <Card>
+                    <span>{this.props.message.user.fullName} - {this.props.message.message}</span>
+                    <p className="timestamp">{formatTimestamp(this.props.message.timestamp).split(",")[0]}<br />
+                        {formatTimestamp(this.props.message.timestamp).split(",")[1]}</p>
                 </Card>
             )
         }

--- a/src/components/message/MessageForm.js
+++ b/src/components/message/MessageForm.js
@@ -5,7 +5,6 @@ import APIManager from "../../modules/APIManager"
 class MessageForm extends Component {
 
     state = {
-        loggedInUserId: 1,
         message: ""
     }
 
@@ -16,7 +15,7 @@ class MessageForm extends Component {
             window.alert("Please enter a message")
         } else {
             const newMessage = {
-                    "userId": this.state.loggedInUserId,
+                    "userId": this.props.getUser.id,
                     "message": this.state.message,
                     "timestamp": createDateTimeToISO()
             }

--- a/src/components/message/MessageList.js
+++ b/src/components/message/MessageList.js
@@ -17,7 +17,6 @@ class MessageList extends Component {
                 messages: messageGetResults
             })
         })
-        
     }
     
     updateMessageArray = () => {
@@ -35,6 +34,7 @@ class MessageList extends Component {
                 <div>
                     <MessageForm
                         updateMessageArray={this.updateMessageArray}
+                        {...this.props}
                     />
                     { this.state.messages.map(message =>
                         <MessageCard 


### PR DESCRIPTION
# Description

- fixed edit to display only for the users messages
- implemented login for messages

Fixes #27, #29 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions

1. "git fetch --all"
2. "git checkout cf-edit"
3. run json server on port 5002 and "npm start"
4. make sure edit button only displays for logged in users messages
5. make sure login is required to access messages page
6. please check that the correct user id is being passed to the database when creating or editing messages

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
